### PR TITLE
Configure proto source dir, include gradle-protobuf defs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,39 +1,32 @@
 //Apply the publishing plugin
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath "com.gradle.publish:plugin-publish-plugin:0.9.8"
-        classpath "gradle.plugin.com.github.maiflai:gradle-scalatest:0.16"
-    }
-}
+//buildscript {
+//    repositories {
+//        maven {
+//            url "https://plugins.gradle.org/m2/"
+//        }
+//    }
+//    dependencies {
+//        classpath "com.gradle.publish:plugin-publish-plugin:0.9.8"
+//        classpath "gradle.plugin.com.github.maiflai:gradle-scalatest:0.16"
+//    }
+//}
 
 plugins {
     id 'scala'
     id 'idea'
     id 'java-gradle-plugin'
-    id 'com.gradle.plugin-publish' version '0.9.7'
+    id 'com.gradle.plugin-publish' version '0.9.9'
+    id 'com.github.maiflai.scalatest' version '0.19'
     id "com.jfrog.bintray" version "1.7.3"
     id 'maven-publish'
 }
 
-apply plugin: "com.github.maiflai.scalatest"
-
 group 'com.charlesahunt'
-version = '1.1.4'
+version = '1.1.5-SNAPSHOT'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-apply plugin: 'scala'
-apply plugin: 'idea'
-apply plugin: 'maven'
-apply plugin: 'java-gradle-plugin'
-apply plugin: 'com.jfrog.bintray'
-apply plugin: "com.gradle.plugin-publish"
 
 repositories {
     jcenter()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Jan 16 16:23:09 PST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.2-all.zip

--- a/src/main/scala/com/charlesahunt/scalapb/ScalaPB.scala
+++ b/src/main/scala/com/charlesahunt/scalapb/ScalaPB.scala
@@ -11,12 +11,11 @@ import sbt.io.{GlobFilter, PathFinder}
 import scala.collection.JavaConverters._
 
 class ScalaPB extends DefaultTask with LazyLogging {
-  private val pluginExtensions: ScalaPBPluginExtension = getProject.getExtensions
+  // needs to be lazy so that the correct options is grabbed at runtime
+  private lazy val pluginExtensions: ScalaPBPluginExtension = getProject.getExtensions
       .findByType(classOf[ScalaPBPluginExtension])
 
-  private val configuredTargetDir: Option[String] = Option(pluginExtensions.targetDir)
-
-  val targetDir: String = if (configuredTargetDir.getOrElse("") == "") "target/scala" else configuredTargetDir.get
+  private lazy val targetDir: String = pluginExtensions.targetDir
 
   @TaskAction
   def compileProtos(): Unit = {
@@ -124,9 +123,6 @@ object ProtocPlugin extends LazyLogging {
                           extractedIncludeDir: String,
                           targetDir: String): Set[File] = {
     val unpackProtosTo = new File(projectRoot, extractedIncludeDir)
-
-    logger.info(s"BUHHHHHHHHH $unpackProtosTo")
-
     val unpackedProtos = unpack(protoIncludePaths, unpackProtosTo)
     logger.info("unpacked Protos:  " + unpackedProtos)
 
@@ -147,7 +143,7 @@ object ProtocPlugin extends LazyLogging {
         protocOptions = Nil,
         targets = Seq(Target(generatorAndOpts = scalapb.gen(), outputPath = new File(s"$projectRoot/$targetDir"))),
         pythonExe = "python",
-        deleteTargetDirectory = false
+        deleteTargetDirectory = true
       )
 //    val cachedCompile = FileFunction.cached(
 //      cacheFile, inStyle = FilesInfo.lastModified, outStyle = FilesInfo.exists) { (in: Set[File]) =>

--- a/src/main/scala/com/charlesahunt/scalapb/ScalaPBPluginExtension.java
+++ b/src/main/scala/com/charlesahunt/scalapb/ScalaPBPluginExtension.java
@@ -7,6 +7,7 @@ public class ScalaPBPluginExtension {
 
     List<String> dependentProtoSources;
     String targetDir;
+    String projectProtoSourceDir;
 
     List<String> getDependentProtoSources() {
         return dependentProtoSources;
@@ -14,6 +15,10 @@ public class ScalaPBPluginExtension {
 
     String getTargetDir() {
         return targetDir;
+    }
+
+    String getProjectProtoSourceDir() {
+        return projectProtoSourceDir;
     }
 
     void setDependentProtoSources(List<String> dependentProtoSources) {
@@ -24,9 +29,16 @@ public class ScalaPBPluginExtension {
         this.targetDir = targetDir;
     }
 
+    void setProjectProtoSourceDir(String projectProtoSourceDir) {
+        this.projectProtoSourceDir = projectProtoSourceDir;
+    }
+
     public ScalaPBPluginExtension() {
         this.dependentProtoSources = new ArrayList<String>();
         this.targetDir = "";
+        this.projectProtoSourceDir = "src/main/protobuf";
     }
+
+
 
 }

--- a/src/main/scala/com/charlesahunt/scalapb/ScalaPBPluginExtension.java
+++ b/src/main/scala/com/charlesahunt/scalapb/ScalaPBPluginExtension.java
@@ -8,6 +8,7 @@ public class ScalaPBPluginExtension {
     List<String> dependentProtoSources;
     String targetDir;
     String projectProtoSourceDir;
+    String extractedIncludeDir;
 
     List<String> getDependentProtoSources() {
         return dependentProtoSources;
@@ -19,6 +20,10 @@ public class ScalaPBPluginExtension {
 
     String getProjectProtoSourceDir() {
         return projectProtoSourceDir;
+    }
+
+    String getExtractedIncludeDir() {
+        return extractedIncludeDir;
     }
 
     void setDependentProtoSources(List<String> dependentProtoSources) {
@@ -33,10 +38,15 @@ public class ScalaPBPluginExtension {
         this.projectProtoSourceDir = projectProtoSourceDir;
     }
 
+    void setExtractedIncludeDir(String extractedIncludeDir) {
+        this.extractedIncludeDir = extractedIncludeDir;
+    }
+
     public ScalaPBPluginExtension() {
         this.dependentProtoSources = new ArrayList<String>();
-        this.targetDir = "";
+        this.targetDir = "target/scala";
         this.projectProtoSourceDir = "src/main/protobuf";
+        this.extractedIncludeDir = "target/external_protos";
     }
 
 


### PR DESCRIPTION
Two smallish changes:
 - specify different project directories for proto sources other than `src/main/protobuf` (e.g. `src/main/proto`)
- gradle work to automatically pick up and include protos extracted by the gradle-protobuf-plugin and copy it to the precompilation dir.