### PR TITLE
Defined task inputs, unpack jar files and allow configuration of grpc flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 group 'com.charlesahunt'
-version = '1.1.5-SNAPSHOT'
+version = '1.1.6'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/scala/com/charlesahunt/scalapb/ScalaPBPluginExtension.java
+++ b/src/main/scala/com/charlesahunt/scalapb/ScalaPBPluginExtension.java
@@ -9,6 +9,7 @@ public class ScalaPBPluginExtension {
     String targetDir;
     String projectProtoSourceDir;
     String extractedIncludeDir;
+    Boolean grpc;
 
     List<String> getDependentProtoSources() {
         return dependentProtoSources;
@@ -26,6 +27,8 @@ public class ScalaPBPluginExtension {
         return extractedIncludeDir;
     }
 
+    Boolean getGrpc() { return grpc; }
+
     void setDependentProtoSources(List<String> dependentProtoSources) {
         this.dependentProtoSources = dependentProtoSources;
     }
@@ -42,13 +45,13 @@ public class ScalaPBPluginExtension {
         this.extractedIncludeDir = extractedIncludeDir;
     }
 
+    void setGrpc(boolean grpc) { this.grpc = grpc; }
+
     public ScalaPBPluginExtension() {
         this.dependentProtoSources = new ArrayList<String>();
         this.targetDir = "target/scala";
         this.projectProtoSourceDir = "src/main/protobuf";
         this.extractedIncludeDir = "target/external_protos";
+        this.grpc = true;
     }
-
-
-
 }


### PR DESCRIPTION
- Defined proto files as task input to trigger rebuid when files has changed
- Added ability to set grpc flag
- Also unpack jar files that might contain proto files (ex the Google ones from protobuf-java package)