### PR TITLE
Update ScalaPB dependencies to lates version with new coordinates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'com.charlesahunt'
-version = '1.1.8'
+version = '1.2.0'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -30,9 +30,9 @@ dependencies {
     compile 'com.github.os72:protoc-jar:3.5.1.1'
     compile 'com.typesafe.scala-logging:scala-logging_2.12:3.7.2'
     compile 'com.google.protobuf:protobuf-java:3.5.1'
-    compile 'com.trueaccord.scalapb:compilerplugin_2.12:0.6.7'
-    compile 'com.trueaccord.scalapb:scalapb-runtime-grpc_2.12:0.6.7'
-    compile 'com.trueaccord.scalapb:scalapb-runtime_2.12:0.6.7'
+    compile 'com.thesamet.scalapb:compilerplugin_2.12:0.7.4'
+    compile 'com.thesamet.scalapb:scalapb-runtime-grpc_2.12:0.7.4'
+    compile 'com.thesamet.scalapb:scalapb-runtime_2.12:0.7.4'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.scalatest:scalatest_2.12:3.0.1'

--- a/src/main/scala/com/charlesahunt/scalapb/ScalaPB.scala
+++ b/src/main/scala/com/charlesahunt/scalapb/ScalaPB.scala
@@ -90,7 +90,7 @@ object ProtocPlugin extends LazyLogging {
       val incPath = includePaths.map("-I" + _.getCanonicalPath)
       protocbridge.ProtocBridge.run(protocCommand, targets,
         incPath ++ protocOptions ++ schemas.map(_.getCanonicalPath),
-          pluginFrontend = protocbridge.frontend.PluginFrontend.newInstance(pythonExe=pythonExe)
+          pluginFrontend = protocbridge.frontend.PluginFrontend.newInstance
       )
     } catch { case e: Exception =>
       throw new RuntimeException("error occurred while compiling protobuf files: %s" format(e.getMessage), e)


### PR DESCRIPTION
Fixes CharlesAHunt/scalapb-gradle-plugin#6

Since the test is failing (see #5 ) I just made those changes hoping it fixes my problem.

When generating with the current version I get this when compiling the generated sources.
`type Lens in package lenses is deprecated (since 0.7.0): Use scalapb.lenses package instead of com.trueaccord.lenses`