### PR TITLE
compilation of dependent protos

### DIFF
--- a/src/main/scala/com/charlesahunt/scalapb/ScalaPBPluginExtension.java
+++ b/src/main/scala/com/charlesahunt/scalapb/ScalaPBPluginExtension.java
@@ -1,20 +1,69 @@
 package com.charlesahunt.scalapb;
 
+import org.gradle.api.file.FileTreeElement;
+import org.gradle.api.specs.Spec;
+import org.gradle.api.tasks.util.PatternFilterable;
+import org.gradle.api.tasks.util.PatternSet;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class ScalaPBPluginExtension {
+    /**
+     * Things to explicitly include as dependent proto sources. These are explicitly recompiled into
+     * scala. These may be .jar, .proto, .zip, almost any archive that could contain protos
+     */
+    List<String> externalProtoSources;
 
-    List<String> dependentProtoSources;
+    /**
+     * e.g. "-v360"
+     */
     String protocVersion;
+
+    /**
+     * Place where generated case classes are placed
+     */
     String targetDir;
+
+    /**
+     * This project's proto source dir. Analogous to srcDir in protobuf-gradle-plugin
+     */
     String projectProtoSourceDir;
+
+    /**
+     * Place to unpack protos extracted from dependentProtoSources
+     */
     String extractedIncludeDir;
+
+    /**
+     * Generate grpc stubs?
+     */
     Boolean grpc;
+
+    /**
+     * Use embedded protoc?
+     */
     Boolean embeddedProtoc;
 
-    List<String> getDependentProtoSources() {
-        return dependentProtoSources;
+    /**
+     * Generate java conversion methods?
+     */
+    Boolean javaConversions;
+
+    /**
+     * When generating scala for proto dependencies of this project, only generate for dependent protos matching this spec
+     */
+    PatternSet dependencySpec;
+
+    /**
+     * If using protobuf-gradle-plugin, where are those outputs copied from (relative to project.projectDir)
+     */
+    String gradleProtobufExtractedPrefix;
+
+
+    List<String> getExternalProtoSources() {
+        return externalProtoSources;
     }
 
     String getProtocVersion() {
@@ -37,8 +86,14 @@ public class ScalaPBPluginExtension {
 
     Boolean getEmbeddedProtoc() { return embeddedProtoc; }
 
-    void setDependentProtoSources(List<String> dependentProtoSources) {
-        this.dependentProtoSources = dependentProtoSources;
+    Boolean getJavaConversions() { return javaConversions; }
+
+    PatternSet getDependencySpec() { return dependencySpec; }
+
+    String getGradleProtobufExtractedPrefix() { return gradleProtobufExtractedPrefix; }
+
+    void setExternalProtoSources(List<String> externalProtoSources) {
+        this.externalProtoSources = externalProtoSources;
     }
 
     void setProtocVersion(String protocVersion) {
@@ -61,13 +116,27 @@ public class ScalaPBPluginExtension {
 
     void setEmbeddedProtoc(boolean embeddedProtoc) { this.embeddedProtoc = embeddedProtoc; }
 
+    void setJavaConversions(boolean javaConversions) { this.javaConversions = javaConversions; }
+
+    void setDependencySpec(PatternFilterable dependencySpec) { this.dependencySpec.copyFrom(dependencySpec); }
+
+    void setGradleProtobufExtractedPrefix(String gradleProtobufExtractedPrefix) {
+        this.gradleProtobufExtractedPrefix = gradleProtobufExtractedPrefix;
+    }
+
     public ScalaPBPluginExtension() {
-        this.dependentProtoSources = new ArrayList<String>();
+        this.externalProtoSources = new ArrayList<String>();
         this.protocVersion = "-v360";
         this.targetDir = "target/scala";
         this.projectProtoSourceDir = "src/main/protobuf";
         this.extractedIncludeDir = "target/external_protos";
         this.grpc = true;
         this.embeddedProtoc = false;
+        this.javaConversions = false;
+        // by default, generate everything. this is how specs are expected to work, but it will take a long time.
+        this.dependencySpec = new PatternSet();
+        // BY CONVENTION, this is usually build/extracted-protos/$sourceSet
+        // where sourceSet is usually main
+        this.gradleProtobufExtractedPrefix = "build/extracted-include-protos/main";
     }
 }

--- a/src/test/scala/com/charlesahunt/scalapb/ScalaPBTest.scala
+++ b/src/test/scala/com/charlesahunt/scalapb/ScalaPBTest.scala
@@ -24,6 +24,7 @@ class ScalaPBTest extends WordSpec {
         "protosTarget", //targetDir,
         true,//grpc
         "-v360",
+        false,
         false
       )
 
@@ -40,7 +41,8 @@ class ScalaPBTest extends WordSpec {
         "protosTarget", //targetDir,
         true,//grpc
         "-v360",
-        true
+        true,
+        false
       )
 
       assert(files.nonEmpty)


### PR DESCRIPTION
protos that gradle-protobuf-plugin extracts will be compiled to scala modulo a gradle PatternSet that you can use to filter them. (if you depend on a proto to define your own, it should probably get compiled to scala or else compileScala will fail).
also generate javaConversion methods if desired (defaults to no).

adds some docs to the pluginExtension class.