### PR TITLE
Update for gradle 5 compatibility

### DIFF
--- a/src/main/scala/com/charlesahunt/scalapb/ScalaPB.scala
+++ b/src/main/scala/com/charlesahunt/scalapb/ScalaPB.scala
@@ -6,13 +6,11 @@ import java.nio.file.Paths
 import com.github.os72.protocjar.ProtocVersion
 import com.typesafe.scalalogging.LazyLogging
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.{OutputDirectory, TaskAction}
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.{InputFiles, OutputDirectory, TaskAction}
 import sbt.io.{GlobFilter, PathFinder}
 
 import scala.collection.JavaConverters._
-import org.gradle.api.file.FileCollection
-import org.gradle.api.internal.file.collections.SimpleFileCollection
-import org.gradle.api.tasks.InputFiles
 
 class ScalaPB extends DefaultTask with LazyLogging {
 
@@ -29,7 +27,7 @@ class ScalaPB extends DefaultTask with LazyLogging {
     val absoluteSourceDir = new File(s"$projectRoot/$projectProtoSourceDir")
     val schemas = ProtocPlugin.collectProtoSources(absoluteSourceDir)
 
-    new SimpleFileCollection(schemas.toList.asJava)
+    getProject.files(schemas.toList.asJava)
   }
 
   @TaskAction
@@ -69,8 +67,9 @@ class ScalaPB extends DefaultTask with LazyLogging {
 }
 
 
-import sbt.io._
 import java.io.File
+
+import sbt.io._
 import protocbridge.Target
 
 object ProtocPlugin extends LazyLogging {


### PR DESCRIPTION
In Gradle 5, the class org.gradle.api.internal.file.collections.SimpleFileCollection has been removed.  In previous versions, the deprecation warning suggest to use the Project.files instead.  This simple change makes this switch.  Unit tests pass successfully when switch to version 5.0 in wrapper properties (although it appears gradle 5.0 automatically adds a wrapper task, so you would have to remove the one defined in build.gradle to test).  This change is also backwards compatible with at least 4.2, the version currently defined in gradle-wrapper.properties.