### PR TITLE
Issue 12 - Kotlin DSL support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,6 @@ repositories {
     mavenCentral()
 }
 
-task wrapper(type: Wrapper) {
-    gradleVersion = "4.8.1"
-}
 
 dependencies {
     compile gradleApi()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jun 22 20:35:01 CDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip

--- a/src/main/scala/com/charlesahunt/scalapb/ScalaPBPluginExtension.java
+++ b/src/main/scala/com/charlesahunt/scalapb/ScalaPBPluginExtension.java
@@ -1,13 +1,10 @@
 package com.charlesahunt.scalapb;
 
-import org.gradle.api.file.FileTreeElement;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 
 public class ScalaPBPluginExtension {
     /**
@@ -62,65 +59,65 @@ public class ScalaPBPluginExtension {
     String gradleProtobufExtractedPrefix;
 
 
-    List<String> getExternalProtoSources() {
+    public List<String> getExternalProtoSources() {
         return externalProtoSources;
     }
 
-    String getProtocVersion() {
+    public String getProtocVersion() {
         return protocVersion;
     }
 
-    String getTargetDir() {
+    public String getTargetDir() {
         return targetDir;
     }
 
-    String getProjectProtoSourceDir() {
+    public String getProjectProtoSourceDir() {
         return projectProtoSourceDir;
     }
 
-    String getExtractedIncludeDir() {
+    public String getExtractedIncludeDir() {
         return extractedIncludeDir;
     }
 
-    Boolean getGrpc() { return grpc; }
+    public Boolean getGrpc() { return grpc; }
 
-    Boolean getEmbeddedProtoc() { return embeddedProtoc; }
+    public Boolean getEmbeddedProtoc() { return embeddedProtoc; }
 
-    Boolean getJavaConversions() { return javaConversions; }
+    public Boolean getJavaConversions() { return javaConversions; }
 
-    PatternSet getDependencySpec() { return dependencySpec; }
+    public PatternSet getDependencySpec() { return dependencySpec; }
 
-    String getGradleProtobufExtractedPrefix() { return gradleProtobufExtractedPrefix; }
+    public String getGradleProtobufExtractedPrefix() { return gradleProtobufExtractedPrefix; }
 
-    void setExternalProtoSources(List<String> externalProtoSources) {
+    public void setExternalProtoSources(List<String> externalProtoSources) {
         this.externalProtoSources = externalProtoSources;
     }
 
-    void setProtocVersion(String protocVersion) {
+    public void setProtocVersion(String protocVersion) {
         this.protocVersion = protocVersion;
     }
 
-    void setTargetDir(String targetDir) {
+    public void setTargetDir(String targetDir) {
         this.targetDir = targetDir;
     }
 
-    void setProjectProtoSourceDir(String projectProtoSourceDir) {
+    public void setProjectProtoSourceDir(String projectProtoSourceDir) {
         this.projectProtoSourceDir = projectProtoSourceDir;
     }
 
-    void setExtractedIncludeDir(String extractedIncludeDir) {
+    public void setExtractedIncludeDir(String extractedIncludeDir) {
         this.extractedIncludeDir = extractedIncludeDir;
     }
 
-    void setGrpc(boolean grpc) { this.grpc = grpc; }
+    public void setGrpc(boolean grpc) { this.grpc = grpc; }
 
-    void setEmbeddedProtoc(boolean embeddedProtoc) { this.embeddedProtoc = embeddedProtoc; }
+    public void setEmbeddedProtoc(boolean embeddedProtoc) { this.embeddedProtoc = embeddedProtoc; }
 
-    void setJavaConversions(boolean javaConversions) { this.javaConversions = javaConversions; }
+    public void setJavaConversions(boolean javaConversions) { this.javaConversions = javaConversions; }
 
-    void setDependencySpec(PatternFilterable dependencySpec) { this.dependencySpec.copyFrom(dependencySpec); }
+    public void setDependencySpec(PatternFilterable dependencySpec) { this.dependencySpec.copyFrom(dependencySpec); }
 
-    void setGradleProtobufExtractedPrefix(String gradleProtobufExtractedPrefix) {
+    public void setGradleProtobufExtractedPrefix(String gradleProtobufExtractedPrefix) {
         this.gradleProtobufExtractedPrefix = gradleProtobufExtractedPrefix;
     }
 


### PR DESCRIPTION
A fresh fix which just uses the latest Gradle release and updates the accessors in the ScalaPBPluginExtension to public in order to make them available to Kotlin based Gradle builds.

No further dependencies (Protoc or Scala) have been touched.

The change has been tested with a Kotlin-Gradle build which was failing before and now succeeds.
In order to test before publishing install the plugin to a local maven-repo (by adding _id 'maven'_ to build.gradle, run the install task, and create a **settings.gradle.kts** in the using project with the following content

```
pluginManagement {
    resolutionStrategy {
        eachPlugin {
            if (requested.id.id == "com.charlesahunt.scalapb") {
                repositories {
                    mavenLocal()
                }
                useModule("com.charlesahunt:scalapb-plugin:1.2.3")
            }
        }
    }
    repositories {
    }
}
```