### PR TITLE
exposing extra scalaPB compiler options

### DIFF
--- a/src/main/scala/com/charlesahunt/scalapb/ScalaPBPluginExtension.java
+++ b/src/main/scala/com/charlesahunt/scalapb/ScalaPBPluginExtension.java
@@ -4,7 +4,9 @@ import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ScalaPBPluginExtension {
     /**
@@ -57,6 +59,12 @@ public class ScalaPBPluginExtension {
      * If using protobuf-gradle-plugin, where are those outputs copied from (relative to project.projectDir)
      */
     String gradleProtobufExtractedPrefix;
+
+    Boolean flatPackage;
+
+    Boolean singleLineToProtoString;
+
+    Boolean asciiFormatToString;
 
 
     public List<String> getExternalProtoSources() {
@@ -121,6 +129,30 @@ public class ScalaPBPluginExtension {
         this.gradleProtobufExtractedPrefix = gradleProtobufExtractedPrefix;
     }
 
+    public Boolean getFlatPackage() {
+        return flatPackage;
+    }
+
+    public void setFlatPackage(Boolean flatPackage) {
+        this.flatPackage = flatPackage;
+    }
+
+    public Boolean getSingleLineToProtoString() {
+        return singleLineToProtoString;
+    }
+
+    public void setSingleLineToProtoString(Boolean singleLineToProtoString) {
+        this.singleLineToProtoString = singleLineToProtoString;
+    }
+
+    public Boolean getAsciiFormatToString() {
+        return asciiFormatToString;
+    }
+
+    public void setAsciiFormatToString(Boolean asciiFormatToString) {
+        this.asciiFormatToString = asciiFormatToString;
+    }
+
     public ScalaPBPluginExtension() {
         this.externalProtoSources = new ArrayList<String>();
         this.protocVersion = "-v360";
@@ -135,5 +167,8 @@ public class ScalaPBPluginExtension {
         // BY CONVENTION, this is usually build/extracted-protos/$sourceSet
         // where sourceSet is usually main
         this.gradleProtobufExtractedPrefix = "build/extracted-include-protos/main";
+        this.flatPackage = false;
+        this.singleLineToProtoString = false;
+        this.asciiFormatToString = false;
     }
 }

--- a/src/test/scala/com/charlesahunt/scalapb/ScalaPBTest.scala
+++ b/src/test/scala/com/charlesahunt/scalapb/ScalaPBTest.scala
@@ -1,12 +1,9 @@
 package com.charlesahunt.scalapb
 
-
 import org.scalatest.WordSpec
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-
-
 @RunWith(classOf[JUnitRunner])
 class ScalaPBTest extends WordSpec {
 
@@ -17,16 +14,16 @@ class ScalaPBTest extends WordSpec {
     "generate Scala classes from the given protos" in {
       val currentPath = new java.io.File(".").getCanonicalPath + "/src/test/"
       val files = ProtocPlugin.sourceGeneratorTask(
-        currentPath, //getProject.getProjectDir.getAbsolutePath,
-        "resources/protos", //projectProtoSourceDir,
-        List(),// internalProtoSources ++ externalProtoSources ++ extractedIncludeDirs,
-        "prefix",
-        "protosCompiled", //pluginExtensions.extractedIncludeDir,
-        "protosTarget", //targetDir,
-        true,//grpc
-        "-v360",
-        false,
-        false
+        projectRoot = currentPath, //getProject.getProjectDir.getAbsolutePath,
+        projectProtoSourceDir = "resources/protos", //projectProtoSourceDir,
+        protoIncludePaths = List(), // internalProtoSources ++ externalProtoSources ++ extractedIncludeDirs,
+        gradleProtobufExtractedPrefix = "prefix",
+        extractedIncludeDir = "protosCompiled", //pluginExtensions.extractedIncludeDir,
+        targetDir = "protosTarget", //targetDir,
+        grpc = true, //grpc
+        protocVersion = "-v360",
+        embeddedProtoc = false,
+        javaConversions = false
       )
 
       assert(files.nonEmpty)
@@ -35,19 +32,43 @@ class ScalaPBTest extends WordSpec {
     "generate scala classes from given protos when embedded is true" in {
       val currentPath = new java.io.File(".").getCanonicalPath + "/src/test/"
       val files = ProtocPlugin.sourceGeneratorTask(
-        currentPath, //getProject.getProjectDir.getAbsolutePath,
-        "resources/protos", //projectProtoSourceDir,
-        List(),// internalProtoSources ++ externalProtoSources ++ extractedIncludeDirs,
-        "prefix",
-        "protosCompiled", //pluginExtensions.extractedIncludeDir,
-        "protosTarget", //targetDir,
-        true,//grpc
-        "-v360",
-        true,
-        false
+        projectRoot = currentPath, //getProject.getProjectDir.getAbsolutePath,
+        projectProtoSourceDir = "resources/protos", //projectProtoSourceDir,
+        protoIncludePaths = List(), // internalProtoSources ++ externalProtoSources ++ extractedIncludeDirs,
+        gradleProtobufExtractedPrefix = "prefix",
+        extractedIncludeDir = "protosCompiled", //pluginExtensions.extractedIncludeDir,
+        targetDir = "protosTarget", //targetDir,
+        grpc = true, //grpc
+        protocVersion = "-v360",
+        embeddedProtoc = true,
+        javaConversions = false
       )
 
       assert(files.nonEmpty)
+    }
+
+    "generate scala classes from given protos taking the flat package options into account" in {
+      val currentPath = new java.io.File(".").getCanonicalPath + "/src/test/"
+      val files = ProtocPlugin.sourceGeneratorTask(
+        projectRoot = currentPath, //getProject.getProjectDir.getAbsolutePath,
+        projectProtoSourceDir = "resources/protos", //projectProtoSourceDir,
+        protoIncludePaths = List(), // internalProtoSources ++ externalProtoSources ++ extractedIncludeDirs,
+        gradleProtobufExtractedPrefix = "prefix",
+        extractedIncludeDir = "protosCompiled", //pluginExtensions.extractedIncludeDir,
+        targetDir = "protosTarget", //targetDir,
+        grpc = true, //grpc
+        protocVersion = "-v360",
+        embeddedProtoc = true,
+        javaConversions = false,
+        flatPackage = true
+      )
+
+      assert(files.nonEmpty)
+
+      files.foreach { f =>
+        assert(f.toString matches ".*/test/[A-z]+.scala")
+      }
+
     }
   }
 }


### PR DESCRIPTION
I exposed the options found here https://scalapb.github.io/scalapbc.html so It would become possible for our case to turn on `flatPackages` on from Gradle instead of adding it to every proto file(also gives problems with our python codeGen). I also expose the other options while I was at it.